### PR TITLE
Convert `build.sh` and `build.cmd` to Executables

### DIFF
--- a/.github/workflows/Docker_build.yml
+++ b/.github/workflows/Docker_build.yml
@@ -32,6 +32,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+      - name: Make build.sh executable
+        run: chmod +x ./build.sh
+      - name: Make build.cmd executable
+        run: chmod +x ./build.cmd
       - uses: actions/setup-dotnet@v1
         with:
           dotnet-version: 5.0.*

--- a/.github/workflows/Windows_release.yml
+++ b/.github/workflows/Windows_release.yml
@@ -27,6 +27,10 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v1
+      - name: Make build.sh executable
+        run: chmod +x ./build.sh
+      - name: Make build.cmd executable
+        run: chmod +x ./build.cmd
       - uses: actions/setup-dotnet@v1
         with:
           dotnet-version: 5.0.*

--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -32,6 +32,10 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v1
+      - name: Make build.sh executable
+        run: chmod +x ./build.sh
+      - name: Make build.cmd executable
+        run: chmod +x ./build.cmd
       - uses: actions/setup-dotnet@v1
         with:
           dotnet-version: 5.0.*
@@ -54,6 +58,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+      - name: Make build.sh executable
+        run: chmod +x ./build.sh
+      - name: Make build.cmd executable
+        run: chmod +x ./build.cmd
       - uses: actions/setup-dotnet@v1
         with:
           dotnet-version: 5.0.*

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -133,8 +133,7 @@
               "PushImage",
               "Restore",
               "RunTests",
-              "ServeDocs",
-              "SetFilePermission"
+              "ServeDocs"
             ]
           }
         },
@@ -168,8 +167,7 @@
               "PushImage",
               "Restore",
               "RunTests",
-              "ServeDocs",
-              "SetFilePermission"
+              "ServeDocs"
             ]
           }
         },

--- a/README.md
+++ b/README.md
@@ -93,7 +93,6 @@ If you desire to add more commands, please see the [Fundamentals](https://nuke.b
 
 The ready-made commands you can start working with (both on **Windows** and **Linux**), are detailed as follows:
 
-* `build.cmd SetFilePermission` - fixes file permission exception you may encounter.
 * `build.cmd Install` - installs Nuke.GlobalTool - which is the default when no command is passed.
 * `build.cmd all` - runs the following commands: `BuildRelease`, `RunTests`, `NBench` and `Nuget`.
 * `build.cmd compile` - compiles the solution in `Release` mode. The default mode is `Release`, to compile in `Debug` mode => `--configuration debug`

--- a/build/Build.CI.GitHubActions.cs
+++ b/build/Build.CI.GitHubActions.cs
@@ -59,7 +59,14 @@ class CustomGitHubActionsAttribute : GitHubActionsAttribute
                 Version = version
             });
         }
-
+        newSteps.Insert(1, new GitHubActionsSetupChmod
+        {
+            File = "build.cmd"
+        });
+        newSteps.Insert(1, new GitHubActionsSetupChmod
+        {
+            File = "build.sh"
+        });
         job.Steps = newSteps.ToArray();
         return job;
     }
@@ -80,6 +87,20 @@ class GitHubActionsSetupDotNetStep : GitHubActionsStep
             {
                 writer.WriteLine($"dotnet-version: {Version}");
             }
+        }
+    }
+}
+
+class GitHubActionsSetupChmod : GitHubActionsStep
+{
+    public string File { get; init; }
+
+    public override void Write(CustomFileWriter writer)
+    {
+        writer.WriteLine($"- name: Make {File} executable");
+        using (writer.Indent())
+        {
+            writer.WriteLine($"run: chmod +x ./{File}");
         }
     }
 }

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -372,14 +372,6 @@ partial class Build : NukeBuild
 
         });
 
-
-    Target SetFilePermission => _ => _
-    .Description("User may experience PERMISSION issues - this target be used to fix that!")
-    .Executes(() =>
-    {
-        Git($"update-index --chmod=+x {RootDirectory}/build.cmd");
-        Git($"update-index --chmod=+x {RootDirectory}/build.sh");
-    });
     Target Install => _ => _
         .Description("Install `Nuke.GlobalTool` and SignClient")
         .Executes(() =>


### PR DESCRIPTION
Fix for https://github.com/petabridge/petabridge-dotnet-new/issues/246

Made `.sh` and `.cmd` files to be `executable` to fix permission exception thrown on linux os
